### PR TITLE
Improve @Parameter handling

### DIFF
--- a/openapi-generator-for-spring-autoconfigure/src/main/java/de/qaware/openapigeneratorforspring/autoconfigure/OpenApiGeneratorOperationParameterAutoConfiguration.java
+++ b/openapi-generator-for-spring-autoconfigure/src/main/java/de/qaware/openapigeneratorforspring/autoconfigure/OpenApiGeneratorOperationParameterAutoConfiguration.java
@@ -28,6 +28,7 @@ import de.qaware.openapigeneratorforspring.common.mapper.ExampleObjectAnnotation
 import de.qaware.openapigeneratorforspring.common.mapper.ExtensionAnnotationMapper;
 import de.qaware.openapigeneratorforspring.common.mapper.ParameterAnnotationMapper;
 import de.qaware.openapigeneratorforspring.common.operation.parameter.DefaultOperationParameterCustomizer;
+import de.qaware.openapigeneratorforspring.common.operation.parameter.converter.DefaultParameterMethodConverterFromParameterAnnotation;
 import de.qaware.openapigeneratorforspring.common.operation.parameter.converter.ParameterMethodConverter;
 import de.qaware.openapigeneratorforspring.common.operation.parameter.customizer.DefaultOperationParameterAnnotationCustomizer;
 import de.qaware.openapigeneratorforspring.common.operation.parameter.customizer.DefaultOperationParameterDeprecatedCustomizer;
@@ -71,6 +72,12 @@ public class OpenApiGeneratorOperationParameterAutoConfiguration {
         return new DefaultParameterAnnotationMapper(
                 schemaAnnotationMapper, contentAnnotationMapper, exampleObjectAnnotationMapper, extensionAnnotationMapper
         );
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public DefaultParameterMethodConverterFromParameterAnnotation defaultParameterMethodConverterFromParameterAnnotation() {
+        return new DefaultParameterMethodConverterFromParameterAnnotation();
     }
 
     @Bean

--- a/openapi-generator-for-spring-common/src/main/java/de/qaware/openapigeneratorforspring/common/filter/handlermethod/ExcludeHiddenHandlerMethodFilter.java
+++ b/openapi-generator-for-spring-common/src/main/java/de/qaware/openapigeneratorforspring/common/filter/handlermethod/ExcludeHiddenHandlerMethodFilter.java
@@ -20,15 +20,15 @@
 
 package de.qaware.openapigeneratorforspring.common.filter.handlermethod;
 
-import de.qaware.openapigeneratorforspring.common.paths.HandlerMethod;
 import de.qaware.openapigeneratorforspring.common.paths.HandlerMethodWithInfo;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
+import lombok.val;
 
 public class ExcludeHiddenHandlerMethodFilter implements HandlerMethodFilter {
     @Override
     public boolean accept(HandlerMethodWithInfo handlerMethodWithInfo) {
-        HandlerMethod handlerMethod = handlerMethodWithInfo.getHandlerMethod();
+        val handlerMethod = handlerMethodWithInfo.getHandlerMethod();
         boolean hiddenOnHandlerMethod = handlerMethod
                 .findAnnotations(Hidden.class)
                 .findAny().isPresent();

--- a/openapi-generator-for-spring-common/src/main/java/de/qaware/openapigeneratorforspring/common/mapper/DefaultParameterAnnotationMapper.java
+++ b/openapi-generator-for-spring-common/src/main/java/de/qaware/openapigeneratorforspring/common/mapper/DefaultParameterAnnotationMapper.java
@@ -59,6 +59,7 @@ public class DefaultParameterAnnotationMapper implements ParameterAnnotationMapp
 
     @Override
     public void applyFromAnnotation(Parameter parameter, io.swagger.v3.oas.annotations.Parameter annotation, MapperContext mapperContext) {
+        setStringIfNotBlank(annotation.name(), parameter::setName);
         setStringIfNotBlank(annotation.in().toString(), parameter::setIn);
         setStringIfNotBlank(annotation.description(), parameter::setDescription);
         if (annotation.required()) {

--- a/openapi-generator-for-spring-common/src/main/java/de/qaware/openapigeneratorforspring/common/operation/parameter/converter/DefaultParameterMethodConverterFromParameterAnnotation.java
+++ b/openapi-generator-for-spring-common/src/main/java/de/qaware/openapigeneratorforspring/common/operation/parameter/converter/DefaultParameterMethodConverterFromParameterAnnotation.java
@@ -1,0 +1,49 @@
+/*-
+ * #%L
+ * OpenAPI Generator for Spring Boot :: Common
+ * %%
+ * Copyright (C) 2020 - 2021 QAware GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package de.qaware.openapigeneratorforspring.common.operation.parameter.converter;
+
+import de.qaware.openapigeneratorforspring.common.paths.HandlerMethod;
+import de.qaware.openapigeneratorforspring.model.parameter.Parameter;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+import static de.qaware.openapigeneratorforspring.common.util.OpenApiOrderedUtils.muchLaterThan;
+
+public class DefaultParameterMethodConverterFromParameterAnnotation implements ParameterMethodConverter {
+
+    public static final int ORDER = muchLaterThan(DEFAULT_ORDER);
+
+    @Nullable
+    @Override
+    public Parameter convert(HandlerMethod.Parameter handlerMethodParameter) {
+        return handlerMethodParameter.getAnnotationsSupplier()
+                .findAnnotations(io.swagger.v3.oas.annotations.Parameter.class)
+                .findFirst()
+                .flatMap(parameterAnnotation -> parameterAnnotation.hidden() ? Optional.empty() : Optional.of(new Parameter()))
+                .orElse(null);
+    }
+
+    @Override
+    public int getOrder() {
+        return ORDER;
+    }
+}

--- a/openapi-generator-for-spring-common/src/main/java/de/qaware/openapigeneratorforspring/common/operation/parameter/customizer/DefaultOperationParameterSchemaCustomizer.java
+++ b/openapi-generator-for-spring-common/src/main/java/de/qaware/openapigeneratorforspring/common/operation/parameter/customizer/DefaultOperationParameterSchemaCustomizer.java
@@ -23,6 +23,7 @@ package de.qaware.openapigeneratorforspring.common.operation.parameter.customize
 import de.qaware.openapigeneratorforspring.common.annotation.AnnotationsSupplier;
 import de.qaware.openapigeneratorforspring.common.reference.component.schema.ReferencedSchemaConsumer;
 import de.qaware.openapigeneratorforspring.common.schema.resolver.SchemaResolver;
+import de.qaware.openapigeneratorforspring.model.parameter.Parameter;
 import lombok.RequiredArgsConstructor;
 
 import static de.qaware.openapigeneratorforspring.common.schema.resolver.SchemaResolver.Mode.FOR_DESERIALIZATION;
@@ -32,7 +33,7 @@ public class DefaultOperationParameterSchemaCustomizer implements OperationParam
     private final SchemaResolver schemaResolver;
 
     @Override
-    public void customize(de.qaware.openapigeneratorforspring.model.parameter.Parameter parameter, OperationParameterCustomizerContext context) {
+    public void customize(Parameter parameter, OperationParameterCustomizerContext context) {
         context.getHandlerMethodParameter().ifPresent(handlerMethodParameter ->
                 handlerMethodParameter.getType().ifPresent(parameterType -> {
                     ReferencedSchemaConsumer referencedSchemaConsumer = context.getReferencedItemConsumer(ReferencedSchemaConsumer.class);

--- a/openapi-generator-for-spring-test/src/test/java/de/qaware/openapigeneratorforspring/test/app50/App50.java
+++ b/openapi-generator-for-spring-test/src/test/java/de/qaware/openapigeneratorforspring/test/app50/App50.java
@@ -1,0 +1,11 @@
+package de.qaware.openapigeneratorforspring.test.app50;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+class App50 {
+    public static void main(String[] args) {
+        SpringApplication.run(App50.class, args);
+    }
+}

--- a/openapi-generator-for-spring-test/src/test/java/de/qaware/openapigeneratorforspring/test/app50/App50Configuration.java
+++ b/openapi-generator-for-spring-test/src/test/java/de/qaware/openapigeneratorforspring/test/app50/App50Configuration.java
@@ -1,0 +1,51 @@
+package de.qaware.openapigeneratorforspring.test.app50;
+
+import de.qaware.openapigeneratorforspring.common.annotation.AnnotationsSupplier;
+import de.qaware.openapigeneratorforspring.common.operation.parameter.customizer.DefaultOperationParameterSchemaCustomizer;
+import de.qaware.openapigeneratorforspring.common.operation.parameter.customizer.OperationParameterCustomizerContext;
+import de.qaware.openapigeneratorforspring.common.reference.component.schema.ReferencedSchemaConsumer;
+import de.qaware.openapigeneratorforspring.common.schema.resolver.SchemaResolver;
+import de.qaware.openapigeneratorforspring.model.parameter.Parameter;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.TypeDescriptor;
+
+import java.lang.reflect.Type;
+
+import static de.qaware.openapigeneratorforspring.common.schema.resolver.SchemaResolver.Mode.FOR_DESERIALIZATION;
+
+@Configuration
+@RequiredArgsConstructor
+public class App50Configuration {
+
+    @Bean
+    public DefaultOperationParameterSchemaCustomizer conversionServiceAwareOperationParameterSchemaCustomizer(SchemaResolver schemaResolver, ConversionService conversionService) {
+        return new DefaultOperationParameterSchemaCustomizer(schemaResolver) {
+            @Override
+            public void customize(Parameter parameter, OperationParameterCustomizerContext context) {
+                context.getHandlerMethodParameter().ifPresent(handlerMethodParameter ->
+                        handlerMethodParameter.getType().ifPresent(parameterType -> {
+                            ReferencedSchemaConsumer referencedSchemaConsumer = context.getReferencedItemConsumer(ReferencedSchemaConsumer.class);
+                            AnnotationsSupplier annotationsSupplier = handlerMethodParameter.getAnnotationsSupplier()
+                                    .andThen(parameterType.getAnnotationsSupplier());
+                            schemaResolver.resolveFromType(FOR_DESERIALIZATION, getType(parameterType.getType()), annotationsSupplier, referencedSchemaConsumer, parameter::setSchema);
+                        })
+                );
+            }
+
+            private Type getType(Type parameterType) {
+                TypeDescriptor parameterTypeDescriptor = new TypeDescriptor(ResolvableType.forType(parameterType), null, null);
+                TypeDescriptor stringType = TypeDescriptor.valueOf(String.class);
+                val canConvertFromString = conversionService.canConvert(stringType, parameterTypeDescriptor);
+                if (canConvertFromString) {
+                    return stringType.getType();
+                }
+                return parameterType;
+            }
+        };
+    }
+}

--- a/openapi-generator-for-spring-test/src/test/java/de/qaware/openapigeneratorforspring/test/app50/App50Controller.java
+++ b/openapi-generator-for-spring-test/src/test/java/de/qaware/openapigeneratorforspring/test/app50/App50Controller.java
@@ -1,0 +1,47 @@
+package de.qaware.openapigeneratorforspring.test.app50;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collections;
+import java.util.List;
+
+@RestController
+@RequestMapping
+class App50Controller {
+
+    @GetMapping("/users/{id}")
+    public List<String> getUsers(
+            @PathVariable("id") UserId userId,
+            @RequestHeader(name = "X-Custom-Header") HeaderDto header
+    ) {
+        return Collections.emptyList();
+    }
+
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter
+    static class UserId {
+        private final String id;
+
+        public static UserId of(String id) {
+            return new UserId(id);
+        }
+    }
+
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter
+    static class HeaderDto {
+        private final String param1;
+        private final String param2;
+
+        public static HeaderDto fromParams(String param1, String param2) {
+            return new HeaderDto(param1, param2);
+        }
+    }
+}

--- a/openapi-generator-for-spring-test/src/test/java/de/qaware/openapigeneratorforspring/test/app50/App50Controller.java
+++ b/openapi-generator-for-spring-test/src/test/java/de/qaware/openapigeneratorforspring/test/app50/App50Controller.java
@@ -1,5 +1,7 @@
 package de.qaware.openapigeneratorforspring.test.app50;
 
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 @RestController
 @RequestMapping
@@ -21,6 +24,11 @@ class App50Controller {
             @PathVariable("id") UserId userId,
             @RequestHeader(name = "X-Custom-Header") HeaderDto header
     ) {
+        return Collections.emptyList();
+    }
+
+    @GetMapping("/users/localized")
+    public List<String> getWithAcceptHeader(@Parameter(in = ParameterIn.HEADER, name = "Accept-Language") Locale locale) {
         return Collections.emptyList();
     }
 

--- a/openapi-generator-for-spring-test/src/test/java/de/qaware/openapigeneratorforspring/test/app50/App50Test.java
+++ b/openapi-generator-for-spring-test/src/test/java/de/qaware/openapigeneratorforspring/test/app50/App50Test.java
@@ -1,0 +1,7 @@
+package de.qaware.openapigeneratorforspring.test.app50;
+
+import de.qaware.openapigeneratorforspring.test.AbstractOpenApiGeneratorWebMvcIntTest;
+
+class App50Test extends AbstractOpenApiGeneratorWebMvcIntTest {
+
+}

--- a/openapi-generator-for-spring-test/src/test/java/de/qaware/openapigeneratorforspring/test/app50/HeaderDtoConverter.java
+++ b/openapi-generator-for-spring-test/src/test/java/de/qaware/openapigeneratorforspring/test/app50/HeaderDtoConverter.java
@@ -1,0 +1,17 @@
+package de.qaware.openapigeneratorforspring.test.app50;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+class HeaderDtoConverter implements Converter<String, App50Controller.HeaderDto> {
+
+    @Override
+    public App50Controller.HeaderDto convert(String source) {
+        String[] split = source.split(";");
+        if (split.length != 2) {
+            return App50Controller.HeaderDto.fromParams("unknown", "unknown");
+        }
+        return App50Controller.HeaderDto.fromParams(split[0], split[1]);
+    }
+}

--- a/openapi-generator-for-spring-test/src/test/resources/openApiJson/app50.json
+++ b/openapi-generator-for-spring-test/src/test/resources/openApiJson/app50.json
@@ -5,6 +5,25 @@
     "version": "unknown"
   },
   "paths": {
+    "/users/localized": {
+      "get": {
+        "operationId": "getWithAcceptHeader",
+        "parameters": [
+          {
+            "name": "Accept-Language",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/200"
+          }
+        }
+      }
+    },
     "/users/{id}": {
       "get": {
         "operationId": "getUsers",
@@ -28,18 +47,30 @@
         ],
         "responses": {
           "200": {
-            "description": "Default response",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              }
+            "$ref": "#/components/responses/200"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "200": {
+        "description": "Default response",
+        "content": {
+          "*/*": {
+            "schema": {
+              "$ref": "#/components/schemas/array_string"
             }
           }
+        }
+      }
+    },
+    "schemas": {
+      "array_string": {
+        "type": "array",
+        "items": {
+          "type": "string"
         }
       }
     }

--- a/openapi-generator-for-spring-test/src/test/resources/openApiJson/app50.json
+++ b/openapi-generator-for-spring-test/src/test/resources/openApiJson/app50.json
@@ -1,0 +1,47 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "API for App50",
+    "version": "unknown"
+  },
+  "paths": {
+    "/users/{id}": {
+      "get": {
+        "operationId": "getUsers",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Custom-Header",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add an example test to show how to use Spring's `ConversionService` bean to detect if a given parameter should be considered as having type `String`.

Also fix #44 by providing a common ParameterMethodConverter which creates an empty `Parameter` model object if an explicit `@Parameter` annotation is present.